### PR TITLE
UNT-T26907: Update SSFacebook Login to Latest and fix privacy manifest issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 let package = Package(
   name: "SSFacebookLogin",
-  platforms: [.iOS(.v12)],
+  platforms: [.iOS(.v13)],
   products: [
     // Products define the executables and libraries a package produces,
     //and make them visible to other packages.
@@ -14,7 +14,7 @@ let package = Package(
     ),
   ],
   dependencies: [  
-   .package(url: "https://github.com/facebook/facebook-ios-sdk.git", from: "17.0.0")
+   .package(url: "https://github.com/facebook/facebook-ios-sdk.git", from: "17.0.2")
   ],
   targets: [
     // Targets are the basic building blocks of a package. 

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 target 'ReuseabelLogInComponets' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - FBAEMKit (17.0.0):
-    - FBSDKCoreKit_Basics (= 17.0.0)
-  - FBSDKCoreKit (17.0.0):
-    - FBAEMKit (= 17.0.0)
-    - FBSDKCoreKit_Basics (= 17.0.0)
-  - FBSDKCoreKit_Basics (17.0.0)
-  - FBSDKLoginKit (17.0.0):
-    - FBSDKCoreKit (= 17.0.0)
+  - FBAEMKit (17.0.2):
+    - FBSDKCoreKit_Basics (= 17.0.2)
+  - FBSDKCoreKit (17.0.2):
+    - FBAEMKit (= 17.0.2)
+    - FBSDKCoreKit_Basics (= 17.0.2)
+  - FBSDKCoreKit_Basics (17.0.2)
+  - FBSDKLoginKit (17.0.2):
+    - FBSDKCoreKit (= 17.0.2)
   - SSFacebookLogin (7.1.0):
-    - FBSDKCoreKit (= 17.0.0)
-    - FBSDKLoginKit (= 17.0.0)
+    - FBSDKCoreKit (= 17.0.2)
+    - FBSDKLoginKit (= 17.0.2)
 
 DEPENDENCIES:
   - SSFacebookLogin (from `./`)
@@ -26,12 +26,12 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  FBAEMKit: 31a20c2d8744d8c57d3a5b7ae4e27b4fdd819193
-  FBSDKCoreKit: dac911b656816f8d0b06e5fa4bac60e89505bb3b
-  FBSDKCoreKit_Basics: 92b7b7458d57091370b0b6cc197578874c3b4b16
-  FBSDKLoginKit: 5d5271ebfd1e39c6b071de8db5c4bd6255be3561
-  SSFacebookLogin: 0dc92fd121c7a1359853fb7467f8ed4566d8eb1e
+  FBAEMKit: 619f96ea65427e8afca240d5b0f4703738dfdf5c
+  FBSDKCoreKit: a5f384db2e9ee84e98494fed8f983d2bd79accff
+  FBSDKCoreKit_Basics: d35c775aaf243a2d731dfae7be3a74b1987285ab
+  FBSDKLoginKit: f8ca5f7ab7c4e5b93e729d94975b0db7fcc511ed
+  SSFacebookLogin: d3a98ec4cde558040852ad6ee626560398d80a8d
 
-PODFILE CHECKSUM: 768c6a449025f43280a39811a8a1a3c0a4fab379
+PODFILE CHECKSUM: 755b9c10c2016ca76e3ea46aa0a830ea33e604f9
 
 COCOAPODS: 1.13.0

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you prefer not to use any of the dependency managers above, you can integrate
 ## Migration Guide
 - For minimum `iOS 11.0` use `6.0.4`
 - For minimum `iOS 12.0` or above use `7.0.0`
+- For minimum `iOS 13.0` or above use `7.1.0`
 
 ## Configure App
 1. Right-click `Info.plist`, and choose **Open As ▸ Source Code**.
@@ -86,7 +87,7 @@ If you prefer not to use any of the dependency managers above, you can integrate
 
 ## Usage example
 
-##### Example 1 (Get default data of user when no any arguments passed)
+##### Example 1 (Get default data of user when no any arguments passed - use this for version 7.0.0 or below)
 
 ```swift
     LoginManager.shared.loginWithFacebook(controller: self, { (token, error) in
@@ -108,7 +109,7 @@ If you prefer not to use any of the dependency managers above, you can integrate
     }
 ```
 
-##### Example 2 (Get specific data of user by passing argument)
+##### Example 2 (Get specific data of user by passing argument - use this for version 7.0.0 or below)
 
 ```swift
 
@@ -129,6 +130,51 @@ If you prefer not to use any of the dependency managers above, you can integrate
     }
 
 ```
+
+##### Example 3 (Get specific data of user by passing argument and passing token to Firebase for using Firebase - use this for version 7.1.0)
+
+```swift
+
+    LoginManager.shared.logInWithFacebookFirebase(permission: [.email, .publicProfile, .userBirthday],
+    requriedFields: [.birthday, .about, .email],  tracking: [.limited || .enabled], controller: self, { (token, nonce, error) in
+    
+    if error == nil {
+        print(token?.userID ?? "",token?.tokenString ?? "")
+    }
+    
+    }) { (userData, error) in
+
+        if error == nil {
+            if let uResult = result  {
+                print(uResult)
+            }
+        }
+    }
+
+```
+
+##### Example 4 (Get specific data of user by passing argument with limted login option - use this for version 7.1.0)
+
+```swift
+
+    LoginManager.shared.login(permission: [.email, .publicProfile, .userBirthday],
+    requriedFields: [.birthday, .about, .email], tracking: [.limited || .enabled],controller: self, { (token, error) in
+    
+    if error == nil {
+        print("token \(token)")
+    }
+    
+    }) { (userData, error) in
+
+        if error == nil {
+            if let uResult = result  {
+                print(uResult)
+            }
+        }
+    }
+
+```
+
 ## 🤝 How to Contribute
 
 Whether you're helping us fix bugs, improve the docs, or a feature request, we'd love to have you! :muscle:

--- a/ReuseabelLogInComponets.xcodeproj/project.pbxproj
+++ b/ReuseabelLogInComponets.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y98X8JAPH6;
 				INFOPLIST_FILE = ReuseabelLogInComponets/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.simformsolutions.ReuseabelLogInComponets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -385,7 +385,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y98X8JAPH6;
 				INFOPLIST_FILE = ReuseabelLogInComponets/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.simformsolutions.ReuseabelLogInComponets;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SSFacebookLogin.podspec
+++ b/SSFacebookLogin.podspec
@@ -12,11 +12,11 @@ Pod::Spec.new do |s|
   s.author           = { 'Sanjaysinh Chauhan' => 'sanjaysinh.C@simformsolutions.com' }
   s.source           = { :git => 'https://github.com/simformsolutions/SSFacebookLogin.git', :tag => s.version.to_s }
  
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
   s.source_files = 'Classes'
 
 
-  s.dependency 'FBSDKLoginKit', '17.0.0'
-  s.dependency 'FBSDKCoreKit', '17.0.0'
+  s.dependency 'FBSDKLoginKit', '17.0.2'
+  s.dependency 'FBSDKCoreKit', '17.0.2'
 
 end


### PR DESCRIPTION
UNT-T26907: Update SSFacebook Login to Latest and fix privacy manifest issue

- Updated to FBSDKLoginKit To 17.0.2
- Added a separate method for limited login for Firebase and normal use case
- Upgraded deployment target to iOS 13 for CryptoKit